### PR TITLE
Limit Size of PRs

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -1,0 +1,17 @@
+name: PR Size Watcher
+on: [pull_request]
+
+jobs:
+  build:
+    name: Check PR size
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ookami-kb/gh-pr-size-watcher@v1
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }} # required
+          errorSize: 500 # optional
+          errorMessage: ':no_entry: PR has more than **{allowed} additions**. Split it into smaller PRs.'
+          warningSize: 333 # optional
+          warningMessage: ':warning: PR has more than **{allowed} additions**. Consider splitting it into smaller PRs.'
+          excludePaths:  |
+            *.md


### PR DESCRIPTION
Limit the size of the PR to 500 and throw a warning above 333 which is the same size as the PR-size: L.